### PR TITLE
[ci][build] Build Triton

### DIFF
--- a/ci/build_triton.sh
+++ b/ci/build_triton.sh
@@ -10,12 +10,6 @@ export HEXAGON_MLIR_ROOT=$PWD
 export TRITON_ROOT=$HEXAGON_MLIR_ROOT/triton
 export LLVM_INSTALL_DIR=$LLVM_PROJECT_BUILD_DIR # Override this path to point to your local LLVM build
 
-# Set clang and clang++ from HOST_TOOLCHAIN
-export CC="${HOST_TOOLCHAIN}/bin/clang"
-export CXX="${HOST_TOOLCHAIN}/bin/clang++"
-export CMAKE_ASM_COMPILER="${HOST_TOOLCHAIN}/bin/clang"
-
-
 source ${HEXAGON_MLIR_ROOT}/ci/setup_triton_env.sh
 
 pip install --upgrade pip setuptools wheel


### PR DESCRIPTION
A CI worfklow to enable build of Triton along with all necessary dependencies: `HEXAGON_SDK`, `HEXAGON_TOOLS`, `HexKL`, `LLVM`, and more..