### PR TITLE
[NFC][GitHub Workflow] Change GitHub workflow mode

### DIFF
--- a/.github/workflows/stale-issues.yaml
+++ b/.github/workflows/stale-issues.yaml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
     - uses: actions/stale@v9
       with:


### PR DESCRIPTION
GitHub workflow mode should be `self-hosted` instead of `ubuntu-latest`