### PR TITLE
[hexagon-mlir][scripts] add scripts to help local build.

### DIFF
--- a/scripts/local_build.sh
+++ b/scripts/local_build.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause.
+# For more license information:
+#   https://github.com/qualcomm/hexagon-mlir/LICENSE.txt
+#
+set -euo pipefail
 set -e
 
 echo "----------------------------------------------------"

--- a/scripts/set_local_env.sh
+++ b/scripts/set_local_env.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause.
+# For more license information:
+#   https://github.com/qualcomm/hexagon-mlir/LICENSE.txt
+#
+set -euo pipefail
 set -x
 
 export HEXAGON_MLIR_ROOT=$PWD


### PR DESCRIPTION
Add a script to facilitate downloading all required components, e.g.
HEXAGON_SDK, LLVM, HEX_KL etc, and build hexagon-mlir and run lit test.