### PR TITLE
Fix LLVM installer directory for Triton build

### DIFF
--- a/ci/build_triton.sh
+++ b/ci/build_triton.sh
@@ -8,7 +8,7 @@
 set -x
 export HEXAGON_MLIR_ROOT=$PWD
 export TRITON_ROOT=$HEXAGON_MLIR_ROOT/triton
-export LLVM_INSTALL_DIR=$LLVM_PROJECT_BUILD_DIR 
+export LLVM_INSTALL_DIR=$LLVM_PROJECT_BUILD_DIR/install
 
 source ${HEXAGON_MLIR_ROOT}/ci/setup_triton_env.sh
 


### PR DESCRIPTION
workflows/build.yml exports LLVM_PROJECT_BUILD_DIR="/local/mnt/workspace/MLIR_build_artifacts/llvm_triton/build/". And, setup_llvm.sh script builds and installs LLVM binaries under ${LLVM_INSTALL_DIR}/build/install.

This PR will fix the build_triton.sh scripts to pickup the correct LLVM installation path.