### PR TITLE
[mlir] Enable inlining for intrinsics

### DIFF
--- a/qcom_hexagon_backend/backend/hexagon_options.py
+++ b/qcom_hexagon_backend/backend/hexagon_options.py
@@ -64,6 +64,7 @@ class HexagonOptions:
     enableVTCMTiling: bool = (
         True  # tile linalg-generic and introduce vtcm address-space
     )
+    enableHVXInlining: bool = False
 
     # This option enables 'seeding' of layout conversion ops around conv2d ops.
     # This introduces some builtin.unrealized_conversion_cast ops, that are expected

--- a/qcom_hexagon_backend/bin/linalg-hexagon-translate.cpp
+++ b/qcom_hexagon_backend/bin/linalg-hexagon-translate.cpp
@@ -128,6 +128,12 @@ LogicalResult translateMain(int argc, char **argv, llvm::StringRef toolName) {
                      "translation"),
       llvm::cl::init(false));
 
+  static llvm::cl::opt<bool> enableHVXInlining(
+      "enable-hvx-inlining",
+      llvm::cl::desc(
+          "Enable aggressive inlining after linking runtime modules"),
+      llvm::cl::init(false));
+
   llvm::InitLLVM y(argc, argv);
 
   registerAsmPrinterCLOptions();
@@ -162,6 +168,9 @@ LogicalResult translateMain(int argc, char **argv, llvm::StringRef toolName) {
 
   if (!noHexagonRuntime)
     mlir::Hexagon::Translate::linkRuntimeModules(llvmContext, llvmIR);
+
+  // Aggressive inlining to improve performance after linking runtime modules
+  cond_run_inliner(llvmIR, enableHVXInlining);
 
   if (emitKind == EmitKind::Obj) {
     std::vector<char> object_code_as_bytes = llvm_module_to_obj_string(llvmIR);

--- a/qcom_hexagon_backend/bin/runtime/IntrinsicsHVX.c
+++ b/qcom_hexagon_backend/bin/runtime/IntrinsicsHVX.c
@@ -20,7 +20,7 @@
 
 #ifndef HEXAGON_INTRIN_INLINE
 #define HEXAGON_INTRIN_INLINE                                                  \
-  inline __attribute__((unused, used, always_inline, visibility("hidden")))
+  __attribute__((unused, used, always_inline, visibility("hidden")))
 #endif
 #ifndef HEXAGON_INTRIN
 #define HEXAGON_INTRIN __attribute__((visibility("hidden")))
@@ -28,7 +28,7 @@
 
 #ifndef MAP_MLIR_TO_QHMATH_DOUBLE_ARGS
 #define MAP_MLIR_TO_QHMATH_DOUBLE_ARGS(FNAME, SUFFIX)                          \
-  HEXAGON_INTRIN HVX_Vector _hexagon_runtime_##FNAME##__##SUFFIX(              \
+  HEXAGON_INTRIN_INLINE HVX_Vector _hexagon_runtime_##FNAME##__##SUFFIX(       \
       HVX_Vector vin1, HVX_Vector vin2) {                                      \
     return qhmath_hvx_##FNAME##_##SUFFIX(vin1, vin2);                          \
   }
@@ -36,7 +36,7 @@
 
 #ifndef MAP_MLIR_TO_QHMATH_SINGLE_ARG
 #define MAP_MLIR_TO_QHMATH_SINGLE_ARG(FNAME, SUFFIX)                           \
-  HEXAGON_INTRIN HVX_Vector _hexagon_runtime_##FNAME##__##SUFFIX(              \
+  HEXAGON_INTRIN_INLINE HVX_Vector _hexagon_runtime_##FNAME##__##SUFFIX(       \
       HVX_Vector vin) {                                                        \
     return qhmath_hvx_##FNAME##_##SUFFIX(vin);                                 \
   }
@@ -48,7 +48,7 @@
 // having the SUFFIX appear twice in the function name.
 #ifndef MAP_MLIR_TO_QHMATH_INTERNAL_SINGLE_ARG
 #define MAP_MLIR_TO_QHMATH_INTERNAL_SINGLE_ARG(FNAME, SUFFIX)                  \
-  HEXAGON_INTRIN HVX_Vector _hexagon_runtime_##FNAME##__##SUFFIX(              \
+  HEXAGON_INTRIN_INLINE HVX_Vector _hexagon_runtime_##FNAME##__##SUFFIX(       \
       HVX_Vector vin) {                                                        \
     return qhmath_hvx_##SUFFIX##_##FNAME##_##SUFFIX(vin);                      \
   }

--- a/qcom_hexagon_backend/bin/runtime/include/Attributes.h
+++ b/qcom_hexagon_backend/bin/runtime/include/Attributes.h
@@ -16,7 +16,7 @@
 
 #ifndef HEXAGON_INTRIN_INLINE
 #define HEXAGON_INTRIN_INLINE                                                  \
-  inline __attribute__((unused, used, always_inline, visibility("hidden")))
+  __attribute__((unused, used, always_inline, visibility("hidden")))
 #endif
 
 #ifndef HEXAGON_INTRIN

--- a/qcom_hexagon_backend/include/hexagon/Conversion/LinalgToLLVM/Passes.td
+++ b/qcom_hexagon_backend/include/hexagon/Conversion/LinalgToLLVM/Passes.td
@@ -131,7 +131,10 @@ def LinalgToLLVM : Pass<"linalg-to-llvm", "mlir::ModuleOp"> {
            "both upper and lower frontier">,
     Option<"enableVectorization", "enable-vectorization", "bool",
           /*default=*/"true",
-          "Enable vectorization for HVX">
+          "Enable vectorization for HVX">,
+    Option<"enableHVXInlining", "enable-hvx-inlining", "bool",
+              /*default=*/"false",
+              "Enable aggressive inlining after linking runtime modules">
    ];
 }
 

--- a/qcom_hexagon_backend/include/hexagon/Target/HEX_LLVMIR/LLVMIRTranslation.h
+++ b/qcom_hexagon_backend/include/hexagon/Target/HEX_LLVMIR/LLVMIRTranslation.h
@@ -56,6 +56,9 @@ llvm_module_to_obj_string(std::unique_ptr<llvm::Module> &llvmModule);
 // Dump Hexagon assembly to file.
 void dumpHexagonAssembly(llvm::Module &module, unsigned moduleId,
                          const std::string &archVersion);
+// Conditionally run aggressive inliner on LLVM module.
+void cond_run_inliner(std::unique_ptr<llvm::Module> &llvmModule,
+                      bool enableInlining);                       
 
 } // namespace hexagon
 } // namespace mlir

--- a/qcom_hexagon_backend/lib/Target/HEX_LLVMIR/LLVMIRTranslation.cpp
+++ b/qcom_hexagon_backend/lib/Target/HEX_LLVMIR/LLVMIRTranslation.cpp
@@ -44,9 +44,19 @@
 #include <llvm/Target/TargetMachine.h>
 #include <llvm/Target/TargetOptions.h>
 #include <llvm/TargetParser/Triple.h>
+#include <llvm/Transforms/IPO/AlwaysInliner.h>
 
 namespace mlir {
 namespace hexagon {
+
+void cond_run_inliner(std::unique_ptr<llvm::Module> &llvmModule,
+                      bool enableInlining) {
+  if (enableInlining) {
+    llvm::legacy::PassManager inlinerPM;
+    inlinerPM.add(llvm::createAlwaysInlinerLegacyPass());
+    inlinerPM.run(*llvmModule);
+  }
+}
 
 static bool linkHexExternLib(llvm::Module &module, llvm::StringRef name,
                              llvm::StringRef path) {

--- a/qcom_hexagon_backend/lib/Target/Linalg_MLLVMIR/MLLVMIRTranslation.cpp
+++ b/qcom_hexagon_backend/lib/Target/Linalg_MLLVMIR/MLLVMIRTranslation.cpp
@@ -93,6 +93,8 @@ void setLinalgToLLVMOptions(
   options.disableLWPLoop = !arch_kwargs.at("disableLWPLoop").compare(TRUE);
   options.enableVectorization =
       !arch_kwargs.at("enableVectorization").compare(TRUE);
+  options.enableHVXInlining =
+      !arch_kwargs.at("enableHVXInlining").compare(TRUE);
 }
 
 namespace mlir {

--- a/qcom_hexagon_backend/python/triton_qcom_hexagon_backend_api.cc
+++ b/qcom_hexagon_backend/python/triton_qcom_hexagon_backend_api.cc
@@ -30,6 +30,7 @@
 #include "llvm/Support/FileUtilities.h"
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/Transforms/IPO.h"
 
 #include "mlir/Conversion/Passes.h"
 #include "mlir/Dialect/Arith/Transforms/Passes.h"
@@ -251,6 +252,10 @@ std::vector<std::vector<char>> translateLinalgToObj(
                      << "\n");
       mlir::Hexagon::Translate::linkRuntimeModules(llvmContext,
                                                    current_llvm_mod);
+      // Aggressive inlining to improve performance after linking runtime
+      // modules Check if inlining is enabled via options_map
+      mlir::hexagon::cond_run_inliner(current_llvm_mod,
+                                      optionsLinalgToLLVM.enableHVXInlining);
 
       // Dumping of the principal module if requested
       if (mlir::hexagon::isEnvTrue("LLVM_IR_ENABLE_DUMP")) {
@@ -315,6 +320,13 @@ std::string translateLinalgToLLVMIR(
     fail("Failed to translate TritonHexagon to LLVM IR.");
 
   mlir::Hexagon::Translate::linkRuntimeModules(llvmContext, llvmModule);
+  // Aggressive inlining to improve performance after linking runtime modules
+  // Check if inlining is enabled via options_map
+  mlir::hexagon::LinalgToLLVMOptions optionsLinalgToLLVM;
+  setLinalgToLLVMOptions(optionsLinalgToLLVM, options_map);
+
+  mlir::hexagon::cond_run_inliner(llvmModule,
+                                  optionsLinalgToLLVM.enableHVXInlining);
 
   std::string str;
   llvm::raw_string_ostream os(str);

--- a/qcom_hexagon_backend/test/Transforms/hvx_inlining.mlir
+++ b/qcom_hexagon_backend/test/Transforms/hvx_inlining.mlir
@@ -1,0 +1,117 @@
+// RUN: linalg-hexagon-translate %s --enable-hvx-inlining=false | FileCheck %s --check-prefix=CHECK-NO-INLINE
+// RUN: linalg-hexagon-translate %s --enable-hvx-inlining=true | FileCheck %s --check-prefix=CHECK-INLINE
+
+// When inlining is disabled, we should see calls to _hexagon_runtime_* functions
+// CHECK-NO-INLINE: call <32 x i32> @_hexagon_runtime_exp__vf
+// CHECK-NO-INLINE: call <32 x i32> @_hexagon_runtime_sin__vf
+// CHECK-NO-INLINE: call <32 x i32> @_hexagon_runtime_cos__vf
+// CHECK-NO-INLINE: call <32 x i32> @_hexagon_runtime_tan__vf
+// CHECK-NO-INLINE: call <32 x i32> @_hexagon_runtime_tanh__vf
+// CHECK-NO-INLINE: call <32 x i32> @_hexagon_runtime_acos__vf
+// CHECK-NO-INLINE: call <32 x i32> @_hexagon_runtime_asin__vf
+// CHECK-NO-INLINE: call <32 x i32> @_hexagon_runtime_atan__vf
+// CHECK-NO-INLINE: call <32 x i32> @_hexagon_runtime_sqrt__vf
+// CHECK-NO-INLINE: call <32 x i32> @_hexagon_runtime_rsqrt__vf
+// CHECK-NO-INLINE: call <32 x i32> @_hexagon_runtime_exp__vhf
+// CHECK-NO-INLINE: call <32 x i32> @_hexagon_runtime_tanh__vhf
+// CHECK-NO-INLINE: call <32 x i32> @_hexagon_runtime_acos__vhf
+// CHECK-NO-INLINE: call <32 x i32> @_hexagon_runtime_asin__vhf
+// CHECK-NO-INLINE: call <32 x i32> @_hexagon_runtime_atan__vhf
+// CHECK-NO-INLINE: call <32 x i32> @_hexagon_runtime_sqrt__vhf
+// CHECK-NO-INLINE: call <32 x i32> @_hexagon_runtime_rsqrt__vhf
+// CHECK-NO-INLINE: call <32 x i32> @_hexagon_runtime_floor__vhf
+// CHECK-NO-INLINE: call <32 x i32> @_hexagon_runtime_ceil__vhf
+// CHECK-NO-INLINE: call <32 x i32> @_hexagon_runtime_floor__vsf
+// CHECK-NO-INLINE: call <32 x i32> @_hexagon_runtime_ceil__vsf
+// CHECK-NO-INLINE: call <32 x i32> @_hexagon_runtime_pow__vf
+// CHECK-NO-INLINE: call <32 x i32> @_hexagon_runtime_pow__vhf
+
+// When inlining is enabled, the runtime functions should be inlined and we shouldn't see the calls
+// CHECK-INLINE-NOT: call {{.*}} @_hexagon_runtime_exp__vf
+// CHECK-INLINE-NOT: call {{.*}} @_hexagon_runtime_sin__vf
+// CHECK-INLINE-NOT: call {{.*}} @_hexagon_runtime_cos__vf
+// CHECK-INLINE-NOT: call {{.*}} @_hexagon_runtime_tan__vf
+// CHECK-INLINE-NOT: call {{.*}} @_hexagon_runtime_tanh__vf
+// CHECK-INLINE-NOT: call {{.*}} @_hexagon_runtime_acos__vf
+// CHECK-INLINE-NOT: call {{.*}} @_hexagon_runtime_asin__vf
+// CHECK-INLINE-NOT: call {{.*}} @_hexagon_runtime_atan__vf
+// CHECK-INLINE-NOT: call {{.*}} @_hexagon_runtime_sqrt__vf
+// CHECK-INLINE-NOT: call {{.*}} @_hexagon_runtime_rsqrt__vf
+// CHECK-INLINE-NOT: call {{.*}} @_hexagon_runtime_exp__vhf
+// CHECK-INLINE-NOT: call {{.*}} @_hexagon_runtime_tanh__vhf
+// CHECK-INLINE-NOT: call {{.*}} @_hexagon_runtime_acos__vhf
+// CHECK-INLINE-NOT: call {{.*}} @_hexagon_runtime_asin__vhf
+// CHECK-INLINE-NOT: call {{.*}} @_hexagon_runtime_atan__vhf
+// CHECK-INLINE-NOT: call {{.*}} @_hexagon_runtime_sqrt__vhf
+// CHECK-INLINE-NOT: call {{.*}} @_hexagon_runtime_rsqrt__vhf
+// CHECK-INLINE-NOT: call {{.*}} @_hexagon_runtime_floor__vhf
+// CHECK-INLINE-NOT: call {{.*}} @_hexagon_runtime_ceil__vhf
+// CHECK-INLINE-NOT: call {{.*}} @_hexagon_runtime_floor__vsf
+// CHECK-INLINE-NOT: call {{.*}} @_hexagon_runtime_ceil__vsf
+// CHECK-INLINE-NOT: call {{.*}} @_hexagon_runtime_pow__vf
+// CHECK-INLINE-NOT: call {{.*}} @_hexagon_runtime_pow__vhf
+
+module attributes {llvm.target_triple = "hexagon"} {
+  // Test function that calls all HVX runtime functions
+  llvm.func @test_hvx_runtime_functions(%arg0: vector<32xi32>, %arg1: vector<32xi32>) -> vector<32xi32> {
+    // Single argument functions - vf suffix
+    %0 = llvm.call @_hexagon_runtime_exp__vf(%arg0) : (vector<32xi32>) -> vector<32xi32>
+    %1 = llvm.call @_hexagon_runtime_sin__vf(%0) : (vector<32xi32>) -> vector<32xi32>
+    %2 = llvm.call @_hexagon_runtime_cos__vf(%1) : (vector<32xi32>) -> vector<32xi32>
+    %3 = llvm.call @_hexagon_runtime_tan__vf(%2) : (vector<32xi32>) -> vector<32xi32>
+    %4 = llvm.call @_hexagon_runtime_tanh__vf(%3) : (vector<32xi32>) -> vector<32xi32>
+    %5 = llvm.call @_hexagon_runtime_acos__vf(%4) : (vector<32xi32>) -> vector<32xi32>
+    %6 = llvm.call @_hexagon_runtime_asin__vf(%5) : (vector<32xi32>) -> vector<32xi32>
+    %7 = llvm.call @_hexagon_runtime_atan__vf(%6) : (vector<32xi32>) -> vector<32xi32>
+    %8 = llvm.call @_hexagon_runtime_sqrt__vf(%7) : (vector<32xi32>) -> vector<32xi32>
+    %9 = llvm.call @_hexagon_runtime_rsqrt__vf(%8) : (vector<32xi32>) -> vector<32xi32>
+    
+    // Single argument functions - vhf suffix
+    %10 = llvm.call @_hexagon_runtime_exp__vhf(%9) : (vector<32xi32>) -> vector<32xi32>
+    %11 = llvm.call @_hexagon_runtime_tanh__vhf(%10) : (vector<32xi32>) -> vector<32xi32>
+    %12 = llvm.call @_hexagon_runtime_acos__vhf(%11) : (vector<32xi32>) -> vector<32xi32>
+    %13 = llvm.call @_hexagon_runtime_asin__vhf(%12) : (vector<32xi32>) -> vector<32xi32>
+    %14 = llvm.call @_hexagon_runtime_atan__vhf(%13) : (vector<32xi32>) -> vector<32xi32>
+    %15 = llvm.call @_hexagon_runtime_sqrt__vhf(%14) : (vector<32xi32>) -> vector<32xi32>
+    %16 = llvm.call @_hexagon_runtime_rsqrt__vhf(%15) : (vector<32xi32>) -> vector<32xi32>
+    %17 = llvm.call @_hexagon_runtime_floor__vhf(%16) : (vector<32xi32>) -> vector<32xi32>
+    %18 = llvm.call @_hexagon_runtime_ceil__vhf(%17) : (vector<32xi32>) -> vector<32xi32>
+    
+    // Single argument functions - vsf suffix
+    %19 = llvm.call @_hexagon_runtime_floor__vsf(%18) : (vector<32xi32>) -> vector<32xi32>
+    %20 = llvm.call @_hexagon_runtime_ceil__vsf(%19) : (vector<32xi32>) -> vector<32xi32>
+    
+    // Double argument functions - vf suffix
+    %21 = llvm.call @_hexagon_runtime_pow__vf(%20, %arg1) : (vector<32xi32>, vector<32xi32>) -> vector<32xi32>
+    
+    // Double argument functions - vhf suffix
+    %22 = llvm.call @_hexagon_runtime_pow__vhf(%21, %arg1) : (vector<32xi32>, vector<32xi32>) -> vector<32xi32>
+    
+    llvm.return %22 : vector<32xi32>
+  }
+  
+  // Function declarations for all HVX runtime functions
+  llvm.func @_hexagon_runtime_exp__vf(vector<32xi32>) -> vector<32xi32> attributes {sym_visibility = "private"}
+  llvm.func @_hexagon_runtime_exp__vhf(vector<32xi32>) -> vector<32xi32> attributes {sym_visibility = "private"}
+  llvm.func @_hexagon_runtime_pow__vf(vector<32xi32>, vector<32xi32>) -> vector<32xi32> attributes {sym_visibility = "private"}
+  llvm.func @_hexagon_runtime_pow__vhf(vector<32xi32>, vector<32xi32>) -> vector<32xi32> attributes {sym_visibility = "private"}
+  llvm.func @_hexagon_runtime_sin__vf(vector<32xi32>) -> vector<32xi32> attributes {sym_visibility = "private"}
+  llvm.func @_hexagon_runtime_cos__vf(vector<32xi32>) -> vector<32xi32> attributes {sym_visibility = "private"}
+  llvm.func @_hexagon_runtime_tan__vf(vector<32xi32>) -> vector<32xi32> attributes {sym_visibility = "private"}
+  llvm.func @_hexagon_runtime_tanh__vf(vector<32xi32>) -> vector<32xi32> attributes {sym_visibility = "private"}
+  llvm.func @_hexagon_runtime_tanh__vhf(vector<32xi32>) -> vector<32xi32> attributes {sym_visibility = "private"}
+  llvm.func @_hexagon_runtime_acos__vf(vector<32xi32>) -> vector<32xi32> attributes {sym_visibility = "private"}
+  llvm.func @_hexagon_runtime_acos__vhf(vector<32xi32>) -> vector<32xi32> attributes {sym_visibility = "private"}
+  llvm.func @_hexagon_runtime_asin__vf(vector<32xi32>) -> vector<32xi32> attributes {sym_visibility = "private"}
+  llvm.func @_hexagon_runtime_asin__vhf(vector<32xi32>) -> vector<32xi32> attributes {sym_visibility = "private"}
+  llvm.func @_hexagon_runtime_atan__vf(vector<32xi32>) -> vector<32xi32> attributes {sym_visibility = "private"}
+  llvm.func @_hexagon_runtime_atan__vhf(vector<32xi32>) -> vector<32xi32> attributes {sym_visibility = "private"}
+  llvm.func @_hexagon_runtime_sqrt__vf(vector<32xi32>) -> vector<32xi32> attributes {sym_visibility = "private"}
+  llvm.func @_hexagon_runtime_sqrt__vhf(vector<32xi32>) -> vector<32xi32> attributes {sym_visibility = "private"}
+  llvm.func @_hexagon_runtime_rsqrt__vf(vector<32xi32>) -> vector<32xi32> attributes {sym_visibility = "private"}
+  llvm.func @_hexagon_runtime_rsqrt__vhf(vector<32xi32>) -> vector<32xi32> attributes {sym_visibility = "private"}
+  llvm.func @_hexagon_runtime_floor__vhf(vector<32xi32>) -> vector<32xi32> attributes {sym_visibility = "private"}
+  llvm.func @_hexagon_runtime_floor__vsf(vector<32xi32>) -> vector<32xi32> attributes {sym_visibility = "private"}
+  llvm.func @_hexagon_runtime_ceil__vhf(vector<32xi32>) -> vector<32xi32> attributes {sym_visibility = "private"}
+  llvm.func @_hexagon_runtime_ceil__vsf(vector<32xi32>) -> vector<32xi32> attributes {sym_visibility = "private"}
+}

--- a/test/python/triton/test_softmax.py
+++ b/test/python/triton/test_softmax.py
@@ -85,6 +85,7 @@ def test_softmax(dtype):
         enableVTCMTiling=False,
         enableConvertToHexagonmem=False,
         enableHexagonmemCopyToDMA=False,
+        enableHVXInlining=True,
     )
 
     reference = torch.nn.functional.softmax(x, dim=1, dtype=dtype)


### PR DESCRIPTION
This PR, worked on by @ibrumar, enables the inlining of HVX intrinsics, which are lowered to when we find suitable math functions in the QHL math library to offload to after the LLVMIR codegen. 