### PR TITLE
[docs] update triton-shared link in docs.

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -91,4 +91,4 @@ The following Triton language features are currently **not supported**:
 - [OpenAI Triton](https://github.com/openai/triton) - Main Triton repository
 - [Triton Language Reference](https://triton-lang.org/main/python-api/triton.language.html) - Language documentation
 - [Triton Tutorials](https://triton-lang.org/main/getting-started/tutorials/index.html) - Learning resources
-- [Triton-Shared Middle Layer](https://github.com/microsoft/triton-shared) - Triton to Linalg toolchain
+- [Triton-Shared Middle Layer](https://github.com/facebookincubator/triton-shared.git) - Triton to Linalg toolchain

--- a/docs/tutorials/triton/flash_attention.md
+++ b/docs/tutorials/triton/flash_attention.md
@@ -29,7 +29,7 @@ The Python Triton kernel undergoes a multi-stage compilation process.
 | Stage | Tool/Library | Description |
 |-------|-------------|-------------|
 | **1** | [triton-compiler](https://github.com/triton-lang/triton) | `Triton Kernel → Triton-IR` |
-| **2** | [triton-shared](https://github.com/microsoft/triton-shared) | `Triton IR → Linalg IR` |
+| **2** | [triton-shared](https://github.com/facebookincubator/triton-shared) | `Triton IR → Linalg IR` |
 | **3** | `linalg-hexagon-opt`/libcall | `Linalg IR → MLIR-LLVM` (ML lowering and opt) |
 | **4** | `linalg-hexagon-translate` | `MLIR-LLVM IR → Object Code` |
 | **5** | Linker | Create `libflash_attention_kernel.so` |

--- a/docs/tutorials/triton/gelu.md
+++ b/docs/tutorials/triton/gelu.md
@@ -30,7 +30,7 @@ The Python Triton kernel undergoes a multi-stage compilation process.
 | Stage | Tool/Library | Description |
 |-------|-------------|-------------|
 | **1** | [triton-compiler](https://github.com/triton-lang/triton) | `Triton Kernel → Triton-IR` |
-| **2** | [triton-shared](https://github.com/microsoft/triton-shared) | `Triton IR → Linalg IR` |
+| **2** | [triton-shared](https://github.com/facebookincubator/triton-shared) | `Triton IR → Linalg IR` |
 | **3** | `linalg-hexagon-opt`/libcall | `Linalg IR → MLIR-LLVM` (ML lowering and opt) |
 | **4** | `linalg-hexagon-translate` | `MLIR-LLVM IR → Object Code` |
 | **5** | Linker | Create `libadd_kernel.so` |

--- a/docs/tutorials/triton/matmul_hexkl.md
+++ b/docs/tutorials/triton/matmul_hexkl.md
@@ -32,7 +32,7 @@ The Python Triton kernel undergoes a multi-stage compilation process.
 | Stage | Tool/Library | Description |
 |-------|-------------|-------------|
 | **1** | [triton-compiler](https://github.com/triton-lang/triton) | `Triton Kernel → Triton-IR` |
-| **2** | [triton-shared](https://github.com/microsoft/triton-shared) | `Triton IR → Linalg IR` |
+| **2** | [triton-shared](https://github.com/facebookincubator/triton-shared) | `Triton IR → Linalg IR` |
 | **3** | `linalg-hexagon-opt`/libcall | `Linalg IR → MLIR-LLVM` (ML lowering and opt) |
 | **4** | `linalg-hexagon-translate` | `MLIR-LLVM IR → Object Code` |
 | **5** | Linker | Create `libmatmul_hexkl.so` |

--- a/docs/tutorials/triton/softmax.md
+++ b/docs/tutorials/triton/softmax.md
@@ -26,7 +26,7 @@ The Python Triton kernel undergoes a multi-stage compilation process.
 | Stage | Tool/Library | Description |
 |-------|-------------|-------------|
 | **1** | [triton-compiler](https://github.com/triton-lang/triton) | `Triton Kernel → Triton-IR` |
-| **2** | [triton-shared](https://github.com/microsoft/triton-shared) | `Triton IR → Linalg IR` |
+| **2** | [triton-shared](https://github.com/facebookincubator/triton-shared) | `Triton IR → Linalg IR` |
 | **3** | `linalg-hexagon-opt`/libcall | `Linalg IR → MLIR-LLVM` (ML lowering and opt) |
 | **4** | `linalg-hexagon-translate` | `MLIR-LLVM IR → Object Code` |
 | **5** | Linker | Create `libsoftmax_kernel.so` |

--- a/docs/tutorials/triton/vector_add.md
+++ b/docs/tutorials/triton/vector_add.md
@@ -31,7 +31,7 @@ The Python Triton kernel undergoes multi-stage compilation process.
 | Stage | Tool/Library | Description |
 |-------|-------------|-------------|
 | **1** | [triton-compiler](https://github.com/triton-lang/triton) | `Triton Kernel → Triton-IR` |
-| **2** | [triton-shared](https://github.com/microsoft/triton-shared) | `Triton IR → Linalg IR` |
+| **2** | [triton-shared](https://github.com/facebookincubator/triton-shared) | `Triton IR → Linalg IR` |
 | **3** | `linalg-hexagon-opt`/libcall | `Linalg IR → MLIR-LLVM` (ML lowering and opt) |
 | **4** | `linalg-hexagon-translate` | `MLIR-LLVM IR → Object Code` |
 | **5** | Linker | Create `libadd_kernel.so` |

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -314,4 +314,4 @@ pytest -sv test/python/torch-mlir/test_softmax_torch.py
 - [OpenAI Triton](https://github.com/openai/triton) - Main Triton repository
 - [Triton Language Reference](https://triton-lang.org/main/python-api/triton.language.html) - Language documentation
 - [Triton Tutorials](https://triton-lang.org/main/getting-started/tutorials/index.html) - Learning resources
-- [Triton-Shared Middle Layer](https://github.com/microsoft/triton-shared) - Triton to Linalg toolchain
+- [Triton-Shared Middle Layer](https://github.com/facebookincubator/triton-shared) - Triton to Linalg toolchain


### PR DESCRIPTION
Changes the link from (https://github.com/microsoft/triton-shared
to https://github.com/facebookincubator/triton-shared in docs.