### PR TITLE
[hexagon-mlir][execution] tools for v81 run

### DIFF
--- a/qcom_hexagon_backend/backend/hexagon_executor.py
+++ b/qcom_hexagon_backend/backend/hexagon_executor.py
@@ -26,9 +26,14 @@ from triton.backends.qcom_hexagon_backend.hexagon_profiler import HexagonProfile
 def _sdk_tool_version(q6_version: str) -> str:
     """Return the SDK prebuilt tool version for the given Hexagon arch version.
 
-    v79+ devices require toolv88; older devices use toolv87.
+    v81+ devices use toolv19; v79-v80 use toolv88; older devices use toolv87.
     """
-    return "v88" if int(q6_version.lstrip("v")) >= 79 else "v87"
+    ver = int(q6_version.lstrip("v"))
+    if ver >= 81:
+        return "v19"
+    if ver >= 79:
+        return "v88"
+    return "v87"
 
 
 def _qhmath_sdk_path(q6_version: str) -> tuple:


### PR DESCRIPTION
Provide SDK prebuilt tool version for v81 otherwise it looks underv88_81 which is not found. Available ones: v81 : toolv19; v79-v80 : toolv88; > v79 : toolv87

Note: HexKL currently fails. Probably another required change is missed out.