### PR TITLE
[test][torch-mlir] Add torch-mlir option `experimental_mutation_support`

### DIFF
--- a/test/python/torch-mlir/gpt2lmheadmodel.py
+++ b/test/python/torch-mlir/gpt2lmheadmodel.py
@@ -104,6 +104,7 @@ def compile_to_linalg(model, input, dump_to_file=None, debug=False) -> str:
         func_name=model.__class__.__name__,
         enable_graph_printing=debug,
         enable_ir_printing=debug,
+        experimental_support_mutation=True,
     )
 
     if dump_to_file:


### PR DESCRIPTION
Add `experimental_mutation_support` option flag that controls whether
 in‑place tensor mutations are preserved etc, to gpt2 test.