### PR TITLE
[hexagon-mlir][target] Use toolv19 for Hexagon v81+ in _sdk_tool_version

### DIFF
--- a/qcom_hexagon_backend/backend/hexagon_executor.py
+++ b/qcom_hexagon_backend/backend/hexagon_executor.py
@@ -26,9 +26,15 @@ from triton.backends.qcom_hexagon_backend.hexagon_profiler import HexagonProfile
 def _sdk_tool_version(q6_version: str) -> str:
     """Return the SDK prebuilt tool version for the given Hexagon arch version.
 
-    v79+ devices require toolv88; older devices use toolv87.
+    v81+ devices use toolv19; v79-v80 devices use toolv88; older devices use toolv87.
     """
-    return "v88" if int(q6_version.lstrip("v")) >= 79 else "v87"
+    v = int(q6_version.lstrip("v"))
+    if v >= 81:
+        return "v19"
+    elif v >= 79:
+        return "v88"
+    else:
+        return "v87"
 
 
 def _qhmath_sdk_path(q6_version: str) -> tuple:


### PR DESCRIPTION
SDK 6.4.0.2 ships hexagon_toolv88 only up to v79;
v81 library is under hexagon_toolv19_v81. 
Extend the version mapping so v81+ resolves to toolv19 instead of
the non-existent toolv88 variant.