### PR TITLE
[HexKL] Bail out if HexKL Libs are not found

### DIFF
--- a/ci/setup_tools.sh
+++ b/ci/setup_tools.sh
@@ -46,24 +46,21 @@ tar -xzf "${INSTALL_DIR}/${TOOLCHAIN_TAR}" -C "${INSTALL_DIR}"
 export HEXAGON_TOOLS="${INSTALL_DIR}/Tools"
 echo "Setting HEXAGON_TOOLS to ${HEXAGON_TOOLS}"
 
-# HexKL 
-KL_VERSION="1.0.0"
-KL_OUTER_ZIP="Hexagon_KL.Core.${KL_VERSION}.Linux-Any.zip"
-KL_URL="https://softwarecenter.qualcomm.com/api/download/software/tools/Hexagon_KL/Linux/${KL_VERSION}/${KL_OUTER_ZIP}"
+# HexKL
+KL_VERSION="1.0.0-beta2"
+KL_ZIP="hexkl-1.0-beta.2.zip"
+KL_URL="https://softwarecenter.qualcomm.com/api/download/software/tools/Hexagon_KL/Linux/Debian/${KL_VERSION}/${KL_ZIP}"
 
 KL_BASE="${INSTALL_DIR}/Hexagon_KL"
 KL_DIR="${KL_BASE}/${KL_VERSION}"
 
-mkdir -p "${KL_BASE}"
+mkdir -p "${KL_DIR}"
 echo "Downloading Hexagon KL version ${KL_VERSION}..."
 
-wget -q --show-progress "${KL_URL}" -O "${KL_BASE}/${KL_OUTER_ZIP}"
+wget -q --show-progress "${KL_URL}" -O "${KL_BASE}/${KL_ZIP}"
 
-INNER_ZIP="hexkl-1.0.0-beta1-6.4.0.0.zip"
-# Make sure inner zip exists inside the outer zip
-unzip -q -j "${KL_BASE}/${KL_OUTER_ZIP}" "${INNER_ZIP}" -d "${KL_BASE}"
 echo "Extracting Hexagon KL..."
-unzip -q "${KL_BASE}/${INNER_ZIP}" -d "${KL_DIR}"
+unzip -q "${KL_BASE}/${KL_ZIP}" -d "${KL_DIR}"
 
 # Locate hexkl_addon directory 
 HEXKL_ADDON_DIR=$(find "${KL_DIR}" -type d -name "hexkl_addon" | head -n 1)

--- a/ci/torch-requirements.txt
+++ b/ci/torch-requirements.txt
@@ -1,7 +1,7 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 -f https://github.com/llvm/torch-mlir-release/releases/expanded_assets/dev-wheels
 --pre
-torch==2.10.0+cpu
-torchvision==0.25.0+cpu
+torch==2.12.0+cpu
+torchvision==0.27.0+cpu
 torch-mlir==20260529.826
 torchao==0.10.0+cpu

--- a/qcom_hexagon_backend/backend/compiler.py
+++ b/qcom_hexagon_backend/backend/compiler.py
@@ -189,7 +189,6 @@ class HexagonBackend(BaseBackend):
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
         passes.common.add_inliner(pm)
-        passes.ttir.add_rewrite_tensor_pointer(pm)
         passes.ttir.add_rewrite_tensor_descriptor_to_pointer(pm, False)
         passes.common.add_canonicalizer(pm)
         passes.ttir.add_combine(pm)

--- a/qcom_hexagon_backend/backend/hexagon_executor.py
+++ b/qcom_hexagon_backend/backend/hexagon_executor.py
@@ -298,14 +298,25 @@ class HexagonExecutor:
             HEXKL_ROOT=self.config.env_vars["HEXKL_ROOT"],
             Q6_VERSION=self.config.Q6_VERSION,
         )
-        if (
-            self.enable_hexkl
-            and os.path.exists(hexkl_dir)
-            and os.path.exists(os.path.join(hexkl_dir, "libhexkl_micro.a"))
-            and os.path.exists(os.path.join(hexkl_dir, "libhexkl_macro.a"))
-        ):
+        if self.enable_hexkl:
             hexkl_micro_a = os.path.join(hexkl_dir, "libhexkl_micro.a")
             hexkl_macro_a = os.path.join(hexkl_dir, "libhexkl_macro.a")
+            missing_hexkl_libs = [
+                path
+                for path in (hexkl_micro_a, hexkl_macro_a)
+                if not os.path.isfile(path)
+            ]
+            if missing_hexkl_libs:
+                missing_paths = "\n".join(f"  - {path}" for path in missing_hexkl_libs)
+                raise FileNotFoundError(
+                    "HexKL is enabled, but required HexKL libraries were not "
+                    "found.\n"
+                    f"Expected HexKL library directory: {hexkl_dir}\n"
+                    f"Missing libraries:\n{missing_paths}\n"
+                    "Set HEXKL_ROOT to a valid HexKL installation or disable "
+                    "HexKL for this compilation."
+                )
+
             runtime_libs.append(hexkl_micro_a)
             runtime_libs.append(hexkl_macro_a)
 
@@ -777,7 +788,8 @@ class HexagonExecutor:
                     self.config.env_vars["HEXAGON_TOOLS"], SIM_Q6SS_PATH
                 )
             ),
-            ("{} -mv{} \
+            (
+                "{} -mv{} \
                 --usefs={}/../Tools/target/hexagon/lib/v{}/G0/pic \
                 --simulated_returnval \
                 --cosim_file {} \
@@ -786,7 +798,8 @@ class HexagonExecutor:
                 {}/rtos/qurt/computev{}/sdksim_bin/runelf.pbn -- \
                 {}/libs/run_main_on_hexagon/ship/hexagon_tool{}_v{}/run_main_on_hexagon_sim \
                 stack_size=0x400000 -- \
-                {}").format(
+                {}"
+            ).format(
                 self.config.HEX_TOOLS["hexagon-sim"],
                 self.config.Q6_VERSION,
                 self.config.env_vars["HEXAGON_TOOLS"],

--- a/scripts/build_hexagon_mlir.sh
+++ b/scripts/build_hexagon_mlir.sh
@@ -110,15 +110,14 @@ cd ${BASE_DIR}
 mkdir -p HEXKL_DIR
 cd HEXKL_DIR
 
-if [[ ! -f Hexagon_KL.Core.1.0.0.Linux-Any.zip ]]; then
+if [[ ! -f hexkl-1.0-beta.2.zip ]]; then
   echo "Downloading Hexagon_KL..."
-  wget https://softwarecenter.qualcomm.com/api/download/software/tools/Hexagon_KL/Linux/1.0.0/Hexagon_KL.Core.1.0.0.Linux-Any.zip
+  wget https://softwarecenter.qualcomm.com/api/download/software/tools/Hexagon_KL/Linux/Debian/1.0.0-beta2/hexkl-1.0-beta.2.zip
 fi
 
 if [[ ! -d hexkl_addon ]]; then
   echo "Extracting Hexagon_KL..."
-  unzip -q Hexagon_KL.Core.1.0.0.Linux-Any.zip
-  unzip -q hexkl-1.0.0-beta1-6.4.0.0.zip
+  unzip -q hexkl-1.0-beta.2.zip
 else
   echo "Hexagon_KL already extracted. Skipping."
 fi


### PR DESCRIPTION
Instead of silently avoiding linking against unavailable HexKL libraries, bail out and expose the issue.